### PR TITLE
fix: deduplicate streaming JSONL records to prevent token over-counting

### DIFF
--- a/cc_stats/parser.py
+++ b/cc_stats/parser.py
@@ -26,6 +26,11 @@ class Message:
     is_tool_result: bool = False
     is_meta: bool = False
     session_id: str = ""
+    # API message ID (e.g. "msg_17738...") for deduplication.
+    # Claude Code writes multiple JSONL entries per streaming API call:
+    # prefill records (output_tokens=1) then a final record with real output.
+    # All entries share the same message_id.
+    message_id: str = ""
 
 
 @dataclass
@@ -92,7 +97,13 @@ def parse_jsonl(path: Path) -> Session:
                 is_tool_result=is_tool_result,
                 is_meta=obj.get("isMeta", False),
                 session_id=obj.get("sessionId", session_id),
+                message_id=raw_msg.get("id", ""),
             ))
+
+    # Deduplicate streaming records: same message_id may appear multiple times
+    # (prefill with output_tokens=1, then final with real output_tokens).
+    # Keep only the record with the largest output_tokens for each message_id.
+    messages = _deduplicate_messages(messages)
 
     return Session(
         session_id=session_id,
@@ -100,6 +111,36 @@ def parse_jsonl(path: Path) -> Session:
         file_path=path,
         messages=messages,
     )
+
+
+def _deduplicate_messages(messages: list[Message]) -> list[Message]:
+    """Deduplicate assistant messages that share the same API message ID.
+
+    Claude Code's JSONL logs multiple entries per streaming API call:
+    prefill records (output_tokens ≤ 1) followed by a final record with real output.
+    For each message_id, keep only the record with the largest output_tokens.
+    Messages without a message_id (e.g. user messages) are kept as-is.
+    """
+    best: dict[str, tuple[int, int]] = {}  # message_id -> (index, output_tokens)
+    to_remove: set[int] = set()
+
+    for i, msg in enumerate(messages):
+        if msg.role != "assistant" or not msg.message_id:
+            continue
+        out = msg.usage.get("output_tokens", 0) or 0
+        if msg.message_id in best:
+            old_idx, old_out = best[msg.message_id]
+            if out > old_out:
+                to_remove.add(old_idx)
+                best[msg.message_id] = (i, out)
+            else:
+                to_remove.add(i)
+        else:
+            best[msg.message_id] = (i, out)
+
+    if not to_remove:
+        return messages
+    return [m for i, m in enumerate(messages) if i not in to_remove]
 
 
 def _path_to_dirname(path: Path) -> str:

--- a/cc_stats_app/swift/Models.swift
+++ b/cc_stats_app/swift/Models.swift
@@ -98,6 +98,11 @@ struct Message: Identifiable, Equatable {
     let timestamp: Date?
     let toolCalls: [ToolCall]
     let tokenUsage: TokenDetail?
+    /// The API message ID from JSONL (e.g. "msg_17738...").
+    /// Used to deduplicate streaming records: Claude Code writes multiple JSONL entries
+    /// per API call (prefill records with output_tokens=1, then a final record with real output).
+    /// All entries share the same message ID.
+    let messageId: String?
 
     init(
         role: String,
@@ -105,7 +110,8 @@ struct Message: Identifiable, Equatable {
         model: String? = nil,
         timestamp: Date? = nil,
         toolCalls: [ToolCall] = [],
-        tokenUsage: TokenDetail? = nil
+        tokenUsage: TokenDetail? = nil,
+        messageId: String? = nil
     ) {
         self.role = role
         self.content = content
@@ -113,6 +119,7 @@ struct Message: Identifiable, Equatable {
         self.timestamp = timestamp
         self.toolCalls = toolCalls
         self.tokenUsage = tokenUsage
+        self.messageId = messageId
     }
 
     static func == (lhs: Message, rhs: Message) -> Bool {

--- a/cc_stats_app/swift/SessionParser.swift
+++ b/cc_stats_app/swift/SessionParser.swift
@@ -109,6 +109,14 @@ final class SessionParser {
     // MARK: - JSONL Parsing
 
     /// Parse a single JSONL session file into a Session object.
+    ///
+    /// ## Streaming deduplication
+    /// Claude Code writes multiple JSONL entries per API call during streaming:
+    /// - Several prefill records with `output_tokens = 1` (same `message.id`)
+    /// - One final record with real `output_tokens` (same `message.id`)
+    /// All share the same `message.id` and `input_tokens`.
+    /// We deduplicate by keeping only the record with the largest `output_tokens`
+    /// for each `message.id`, so token usage is not double-counted.
     private func parseSessionFile(_ filePath: String, projectPath: String) -> Session? {
         guard let data = fileManager.contents(atPath: filePath),
               let content = String(data: data, encoding: .utf8) else {
@@ -126,6 +134,11 @@ final class SessionParser {
 
         guard !messages.isEmpty else { return nil }
 
+        // Deduplicate streaming records: same message.id may appear multiple times
+        // (prefill with output_tokens=1, then final with real output_tokens).
+        // Keep only the record with the largest output_tokens for each message ID.
+        messages = deduplicateMessages(messages)
+
         let decodedProjectPath = decodeProjectPath(from: projectPath)
 
         return Session(
@@ -133,6 +146,42 @@ final class SessionParser {
             messages: messages,
             projectPath: decodedProjectPath
         )
+    }
+
+    /// Deduplicate assistant messages that share the same API message ID.
+    ///
+    /// Claude Code's JSONL logs multiple entries per streaming API call:
+    /// prefill records (output_tokens ≤ 1) followed by a final record with real output.
+    /// For each message ID, keep only the record with the largest output_tokens.
+    /// Messages without a messageId (e.g. user messages) are kept as-is.
+    private func deduplicateMessages(_ messages: [Message]) -> [Message] {
+        var bestByMsgId: [String: (index: Int, outputTokens: Int)] = [:]
+        var indicesToRemove = Set<Int>()
+
+        for (i, msg) in messages.enumerated() {
+            guard msg.role == "assistant",
+                  let msgId = msg.messageId,
+                  let usage = msg.tokenUsage else {
+                continue
+            }
+
+            if let existing = bestByMsgId[msgId] {
+                if usage.outputTokens > existing.outputTokens {
+                    indicesToRemove.insert(existing.index)
+                    bestByMsgId[msgId] = (index: i, outputTokens: usage.outputTokens)
+                } else {
+                    indicesToRemove.insert(i)
+                }
+            } else {
+                bestByMsgId[msgId] = (index: i, outputTokens: usage.outputTokens)
+            }
+        }
+
+        guard !indicesToRemove.isEmpty else { return messages }
+
+        return messages.enumerated().compactMap { (i, msg) in
+            indicesToRemove.contains(i) ? nil : msg
+        }
     }
 
     /// Parse a single JSONL line into a Message, if possible.
@@ -168,6 +217,9 @@ final class SessionParser {
         // Extract model
         let model = messageObj?["model"] as? String
 
+        // Extract API message ID for deduplication
+        let messageId = messageObj?["id"] as? String
+
         // Extract content and tool calls
         let (content, toolCalls) = extractContent(from: messageObj, timestamp: timestamp)
 
@@ -180,7 +232,8 @@ final class SessionParser {
             model: model,
             timestamp: timestamp,
             toolCalls: toolCalls,
-            tokenUsage: tokenUsage
+            tokenUsage: tokenUsage,
+            messageId: messageId
         )
     }
 


### PR DESCRIPTION
## 中文说明

### 问题

Claude Code 在流式响应时，对每个 API 调用会写入多条 JSONL 记录：
- 若干 **prefill 记录**（`output_tokens = 1`）
- 最后一条 **final 记录**（包含真实的 `output_tokens`）

这些记录共享相同的 `message.id` 和 `input_tokens`。

在没有去重的情况下，**input tokens 被多计约 58%**，因为每条 prefill 记录都包含完整的 `input_tokens` 值。这导致费用估算偏高。

### 修复方案

对共享相同 `message.id` 的 assistant 消息去重，仅保留 `output_tokens` 最大的那条记录：

- **Python parser** (`cc_stats/parser.py`)：Message 新增 `message_id` 字段 + `_deduplicate_messages()` 函数
- **Swift Models** (`Models.swift`)：Message 结构体新增 `messageId` 属性
- **Swift SessionParser** (`SessionParser.swift`)：从 JSONL 提取 `message.id` + `deduplicateMessages()` 方法

### 验证

以一个真实会话为例验证：
- 修复前：cc-stats 统计的 input tokens 比 `/cost` 高出约 58%
- 修复后：cc-stats 与 `/cost` 的 input tokens 基本一致

---

## English

### Problem

Claude Code writes multiple JSONL entries per API call during streaming:
- Several **prefill records** with `output_tokens = 1`
- One **final record** with the real `output_tokens`

All entries share the same `message.id` and `input_tokens`.

Without deduplication, **input tokens are over-counted by ~58%** because each prefill record repeats the full `input_tokens` value. This inflates cost estimates.

### Fix

Deduplicate assistant messages sharing the same `message.id`, keeping only the record with the largest `output_tokens`:

- **Python parser** (`cc_stats/parser.py`): add `message_id` field to Message + `_deduplicate_messages()`
- **Swift Models** (`Models.swift`): add `messageId` property to Message struct
- **Swift SessionParser** (`SessionParser.swift`): extract `message.id` from JSONL + `deduplicateMessages()`

### Verification

Tested against a real session:
- Before fix: cc-stats input tokens ~58% higher than `/cost`
- After fix: cc-stats input tokens closely match `/cost`