### PR TITLE
perf: split data loading from filtering + single-pass daily stats

### DIFF
--- a/cc_stats_app/swift/StatsViewModel.swift
+++ b/cc_stats_app/swift/StatsViewModel.swift
@@ -145,10 +145,8 @@ final class StatsViewModel: ObservableObject {
     // MARK: - Core Refresh Pipeline
 
     /// 完整刷新 = 磁盘加载（重） + 内存筛选（轻）
+    /// isLoading 由 applyFilterAndUpdate 统一管理。
     private func fullRefresh() async {
-        isLoading = true
-        defer { isLoading = false }
-
         await loadData()
         await applyFilterAndUpdate()
     }
@@ -256,26 +254,17 @@ final class StatsViewModel: ObservableObject {
                 .sorted { ($0.endTime ?? .distantPast) > ($1.endTime ?? .distantPast) }
                 .prefix(30).map { $0 }
 
-            // 计算当天 token
-            let todayStart = Calendar.current.startOfDay(for: Date())
-            let todaySessions = sessions.filter { session in
-                session.messages.contains { $0.timestamp.map { $0 >= todayStart } ?? false }
-            }
-            let todayStats = SessionAnalyzer.analyze(
-                sessions: todaySessions,
-                since: todayStart
-            )
-
-            // 14 天日统计（单次分桶算法）
+            // 14 天日统计（单次分桶算法，today 是最后一个桶）
             let daily = Self.computeDailyStats(from: sessions)
+            let todayPoint = daily.last
             let weeklyCost = daily.suffix(7).reduce(0.0) { $0 + $1.cost }
 
             return FilterResult(
                 stats: stats,
                 recentSessions: recent,
-                todayTokens: todayStats.totalTokens,
-                todayCost: todayStats.estimatedCost,
-                todaySessions: todaySessions.count,
+                todayTokens: todayPoint?.tokens ?? 0,
+                todayCost: todayPoint?.cost ?? 0,
+                todaySessions: todayPoint?.sessions ?? 0,
                 dailyStats: daily,
                 weeklyCost: weeklyCost
             )
@@ -314,6 +303,7 @@ final class StatsViewModel: ObservableObject {
 
     /// 单次遍历将 sessions 按天分桶，替代 14 次循环遍历。
     /// 复杂度从 O(14 × N × M) 降到 O(N × M + 14 × bucket_size)。
+    /// 最后一个桶（index 13）是今天的数据，可直接用于 todayTokens/todayCost。
     nonisolated static func computeDailyStats(from sessions: [Session]) -> [DailyStatPoint] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
@@ -322,9 +312,9 @@ final class StatsViewModel: ObservableObject {
         }
 
         // 一次遍历，按天分桶
-        var buckets: [Set<Int>] = Array(repeating: [], count: 14)
+        var buckets: [[Session]] = Array(repeating: [], count: 14)
 
-        for (sessionIdx, session) in sessions.enumerated() {
+        for session in sessions {
             var seenDays = Set<Int>()
             for msg in session.messages {
                 guard let ts = msg.timestamp, ts >= rangeStart else { continue }
@@ -333,7 +323,7 @@ final class StatsViewModel: ObservableObject {
                 seenDays.insert(dayOffset)
             }
             for day in seenDays {
-                buckets[day].insert(sessionIdx)
+                buckets[day].append(session)
             }
         }
 
@@ -343,7 +333,7 @@ final class StatsViewModel: ObservableObject {
 
         return (0..<14).map { i in
             let dayStart = calendar.date(byAdding: .day, value: i, to: rangeStart)!
-            let daySessions = buckets[i].map { sessions[$0] }
+            let daySessions = buckets[i]
             let dayStats = SessionAnalyzer.analyze(sessions: daySessions, since: dayStart)
 
             return DailyStatPoint(


### PR DESCRIPTION
## 中文说明

### 问题

当前 `StatsViewModel.performRefresh()` 是一个 78 行的方法，同时负责磁盘加载和内存筛选。切换时间筛选器（今天/本周/本月/全部）时，虽然有缓存避免重新读取磁盘，但仍需执行完整的分析流程。同时 14 天日统计使用 14 次循环遍历所有 sessions，存在 O(14 × N × M) 的冗余计算。

### 优化方案

#### 1. 数据加载与筛选分离

将 `performRefresh()` 拆分为两个阶段：
- **`loadData()`**：重量级磁盘 I/O，仅在数据源/项目变更时调用
- **`applyFilterAndUpdate()`**：轻量级内存筛选和分析

`setTimeFilter()` 切换时间筛选器时，如果缓存存在直接走 `applyFilterAndUpdate()` 快速路径，**完全跳过磁盘 I/O 和数据重新解析**。

#### 2. 14 天日统计单次分桶

将原来的 14 次循环遍历改为单次分桶算法 `computeDailyStats()`：
- **优化前**：`O(14 × N × M)` — 循环 14 天，每次扫描全部 sessions 的全部 messages
- **优化后**：`O(N × M + 14 × bucket_size)` — 一次遍历按天分桶，再逐桶分析

`computeDailyStats()` 是 `nonisolated static` 方法，可独立单测。

#### 3. projects/stats 赋值时序修复（PR #4 review 反馈）

将 projects 和 stats 在 `applyFilterAndUpdate()` 中统一赋值，避免 projects 先更新、stats 后更新导致的两帧 UI 闪烁。

### 改动文件

| 文件 | 改动 |
|------|------|
| `cc_stats_app/swift/StatsViewModel.swift` | 拆分 `fullRefresh()` → `loadData()` + `applyFilterAndUpdate()` + `computeDailyStats()` |

### 基于版本

基于最新 `main`（含 `1614cd3` 流式去重、Gemini parser、速率限制等），无冲突。

---

## English

### Problem

`StatsViewModel.performRefresh()` is a 78-line method that handles both disk loading and in-memory filtering. When switching time filters (today/week/month/all), the full analysis pipeline runs even though cached sessions avoid disk re-reads. Additionally, the 14-day daily stats computation iterates all sessions 14 times at O(14 × N × M).

### Optimization

#### 1. Separate data loading from filtering

Split `performRefresh()` into two phases:
- **`loadData()`**: heavy disk I/O, only runs when source/project changes
- **`applyFilterAndUpdate()`**: lightweight in-memory filtering and analysis

`setTimeFilter()` takes a fast path via `applyFilterAndUpdate()` when cache is available, **completely skipping disk I/O and re-parsing**.

#### 2. Single-pass daily stats bucketing

Replace the 14-iteration daily stats loop with single-pass bucketing `computeDailyStats()`:
- **Before**: `O(14 × N × M)` — loop 14 days, each scanning all sessions and messages
- **After**: `O(N × M + 14 × bucket_size)` — one pass to bucket sessions by day, then analyze each small bucket

`computeDailyStats()` is a `nonisolated static` method, independently testable.

#### 3. Fix projects/stats update timing (PR #4 review feedback)

Projects and stats are now assigned together in `applyFilterAndUpdate()` to avoid two-frame UI flicker.

### Files Changed

| File | Change |
|------|--------|
| `cc_stats_app/swift/StatsViewModel.swift` | Split into `fullRefresh()` → `loadData()` + `applyFilterAndUpdate()` + `computeDailyStats()` |

### Based On

Rebased on latest `main` (includes `1614cd3` streaming dedup, Gemini parser, rate limit, etc.), no conflicts.