### PR TITLE
fix: escape strings in AppleScript notification

### DIFF
--- a/cc_stats_app/swift/StatsViewModel.swift
+++ b/cc_stats_app/swift/StatsViewModel.swift
@@ -340,8 +340,15 @@ final class StatsViewModel: ObservableObject {
     }
 
     private func sendSystemNotification(title: String, body: String) {
+        // Escape backslashes and double quotes to prevent AppleScript injection
+        let safeTitle = title
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let safeBody = body
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
         let script = """
-        display notification "\(body)" with title "\(title)" sound name "Glass"
+        display notification "\(safeBody)" with title "\(safeTitle)" sound name "Glass"
         """
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")


### PR DESCRIPTION
## Summary

- Fix potential AppleScript injection in `sendSystemNotification()` — title and body strings were interpolated directly into AppleScript without escaping
- A cost string containing double quotes (e.g. from locale formatting) could break the notification or allow command injection
- Now escapes both backslashes and double quotes before interpolation

## Test plan

- [ ] Compile and run `cc-stats-app`
- [ ] Set a daily cost limit lower than current usage to trigger an alert notification
- [ ] Verify the macOS notification appears correctly
- [ ] Manually test with a cost format that includes special characters (quotes, backslashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)