### PR TITLE
refactor: use TokenDetail += operator in SessionAnalyzer

### DIFF
--- a/cc_stats_app/swift/SessionAnalyzer.swift
+++ b/cc_stats_app/swift/SessionAnalyzer.swift
@@ -91,16 +91,7 @@ class SessionAnalyzer {
             }
 
             for (model, detail) in s.tokenUsage {
-                if let existing = mergedTokenUsage[model] {
-                    mergedTokenUsage[model] = TokenDetail(
-                        inputTokens: existing.inputTokens + detail.inputTokens,
-                        outputTokens: existing.outputTokens + detail.outputTokens,
-                        cacheCreationInputTokens: existing.cacheCreationInputTokens + detail.cacheCreationInputTokens,
-                        cacheReadInputTokens: existing.cacheReadInputTokens + detail.cacheReadInputTokens
-                    )
-                } else {
-                    mergedTokenUsage[model] = detail
-                }
+                mergedTokenUsage[model, default: TokenDetail()] += detail
             }
 
             mergedCodeChanges.append(contentsOf: s.codeChanges)
@@ -333,16 +324,7 @@ class SessionAnalyzer {
         var usage: [String: TokenDetail] = [:]
         for msg in messages {
             guard let model = msg.model, let detail = msg.tokenUsage else { continue }
-            if let existing = usage[model] {
-                usage[model] = TokenDetail(
-                    inputTokens: existing.inputTokens + detail.inputTokens,
-                    outputTokens: existing.outputTokens + detail.outputTokens,
-                    cacheCreationInputTokens: existing.cacheCreationInputTokens + detail.cacheCreationInputTokens,
-                    cacheReadInputTokens: existing.cacheReadInputTokens + detail.cacheReadInputTokens
-                )
-            } else {
-                usage[model] = detail
-            }
+            usage[model, default: TokenDetail()] += detail
         }
         return usage
     }


### PR DESCRIPTION
## Summary

- Replace manual 4-field `TokenDetail` addition (if-let/else + explicit constructor) with the `+=` operator already defined in `Models.swift` but never used
- Applies to both `merge()` and `aggregateTokenUsage()` in `SessionAnalyzer.swift`
- Uses Swift's dictionary subscript default value pattern (`dict[key, default: TokenDetail()] += value`) to eliminate branching
- Net: -20 lines, +2 lines, identical behavior

## Test plan

- [ ] Compile and run `cc-stats-app`
- [ ] Verify token usage breakdown by model is unchanged
- [ ] Verify total token counts and cost estimates are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)