### PR TITLE
fix: tab switch loading + full-view overlay

### DIFF
--- a/cc_stats_app/swift/StatsViewModel.swift
+++ b/cc_stats_app/swift/StatsViewModel.swift
@@ -135,6 +135,7 @@ final class StatsViewModel: ObservableObject {
 
     func selectSource(_ source: DataSource) {
         selectedSource = source
+        activeTab = (source == .cursor) ? .cursor : .claudeCode
         invalidateCache()
         refresh()
     }
@@ -365,7 +366,7 @@ final class StatsViewModel: ObservableObject {
             return DailyStatPoint(
                 date: dayStart,
                 label: formatter.string(from: dayStart),
-                sessions: daySessions.count,
+                sessions: buckets[i].count,
                 messages: dayStats.userInstructions,
                 tokens: dayStats.totalTokens,
                 cost: dayStats.estimatedCost,

--- a/cc_stats_app/swift/Views/DashboardView.swift
+++ b/cc_stats_app/swift/Views/DashboardView.swift
@@ -140,23 +140,30 @@ struct DashboardView: View {
             }
 
             // Loading overlay
-            if viewModel.isLoading && viewModel.stats != nil {
-                Color.black.opacity(0.3)
-                    .ignoresSafeArea()
-                VStack(spacing: 10) {
-                    ProgressView()
-                        .scaleEffect(1.2)
-                        .tint(.white)
-                    Text(L10n.loading)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(.white)
+            ZStack {
+                if viewModel.isLoading && viewModel.stats != nil {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+
+                    VStack(spacing: 16) {
+                        TimelineView(.animation) { timeline in
+                            Circle()
+                                .trim(from: 0, to: 0.7)
+                                .stroke(Theme.cyan, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                                .frame(width: 40, height: 40)
+                                .rotationEffect(.degrees(timeline.date.timeIntervalSince1970.truncatingRemainder(dividingBy: 3.6) * 100))
+                        }
+
+                        Text(L10n.loading)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(Theme.textPrimary)
+                    }
+                    .padding(28)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(Theme.cardBackground.opacity(0.95))
+                    )
                 }
-                .padding(20)
-                .background(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(.ultraThinMaterial)
-                )
-                .transition(.opacity)
             }
         }
         .frame(width: 480)
@@ -239,7 +246,7 @@ struct DashboardView: View {
                 )
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    viewModel.activeTab = tab
+                    viewModel.selectSource(tab == .claudeCode ? .claudeCode : .cursor)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add full-view loading overlay with `TimelineView`-based spinning ring animation
- Tab clicks now call `selectSource()` instead of directly setting `activeTab`, keeping tab highlight in sync
- Fix rotation formula using `truncatingRemainder(dividingBy: 3.6) * 100` to cap rotation cycle

## Resolved Review Issues
- ✅ Removed duplicate `L10n.loading` (main already has it)
- ✅ Fixed `TimelineView` rotation speed formula

## Merge Note
⚠️ When merging, the existing `ProgressView`-based loading overlay in main (DashboardView ~122-140) needs to be removed to avoid duplicate overlays. The new `TimelineView` version should replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)